### PR TITLE
Add Anthropic provider

### DIFF
--- a/lib/src/providers/implementations/anthropic_provider.dart
+++ b/lib/src/providers/implementations/anthropic_provider.dart
@@ -1,0 +1,163 @@
+import 'dart:convert';
+
+import 'package:anthropic_sdk_dart/anthropic_sdk_dart.dart';
+import 'package:flutter/foundation.dart';
+
+import '../../llm_exception.dart';
+import '../interface/attachments.dart';
+import '../interface/chat_message.dart';
+import '../interface/llm_provider.dart';
+import '../interface/message_origin.dart';
+
+/// A provider for Anthropic's language models (Claude).
+///
+/// This provider implements the [LlmProvider] interface to integrate Anthropic's
+/// models into the chat interface.
+class AnthropicProvider extends LlmProvider with ChangeNotifier {
+  /// Creates an Anthropic provider instance.
+  ///
+  /// The [apiKey] parameter is required for authentication with Anthropic's API.
+  AnthropicProvider({
+    required String apiKey,
+    String? baseUrl,
+    Map<String, String>? headers,
+    Map<String, String>? queryParams,
+    String model = 'claude-3-5-sonnet-latest',
+  })  : _client = AnthropicClient(
+          apiKey: apiKey,
+          baseUrl: baseUrl,
+          headers: {
+            'anthropic-dangerous-direct-browser-access': 'true',
+            if (headers != null) ...headers,
+          },
+          queryParams: queryParams,
+        ),
+        _model = model,
+        _history = [];
+
+  final AnthropicClient _client;
+  final String _model;
+  final List<ChatMessage> _history;
+
+  @override
+  Stream<String> generateStream(
+    String prompt, {
+    Iterable<Attachment> attachments = const [],
+  }) async* {
+    final messages = _mapToAnthropicMessages([
+      ChatMessage.user(prompt, attachments),
+    ]);
+
+    yield* _generateStream(messages);
+  }
+
+  @override
+  Stream<String> sendMessageStream(
+    String prompt, {
+    Iterable<Attachment> attachments = const [],
+  }) async* {
+    final userMessage = ChatMessage.user(prompt, attachments);
+    final llmMessage = ChatMessage.llm();
+    _history.addAll([userMessage, llmMessage]);
+
+    final messages = _mapToAnthropicMessages(_history);
+    final stream = _generateStream(messages);
+
+    // don't write this code if you're targeting the web until this is fixed:
+    // https://github.com/dart-lang/sdk/issues/47764
+    // await for (final chunk in stream) {
+    //   llmMessage.append(chunk);
+    //   yield chunk;
+    // }
+    yield* stream.map((chunk) {
+      llmMessage.append(chunk);
+      return chunk;
+    });
+
+    notifyListeners();
+  }
+
+  @override
+  Iterable<ChatMessage> get history => _history;
+
+  @override
+  set history(Iterable<ChatMessage> history) {
+    _history.clear();
+    _history.addAll(history);
+    notifyListeners();
+  }
+
+  Stream<String> _generateStream(List<Message> messages) async* {
+    final stream = _client.createMessageStream(
+      request: CreateMessageRequest(
+        model: Model.modelId(_model),
+        messages: messages,
+        maxTokens: 1024,
+      ),
+    );
+
+    yield* stream.map((event) {
+      return event.mapOrNull(
+            contentBlockDelta: (e) => e.delta.text,
+            error: (e) => throw LlmFailureException(e.error.message),
+          ) ??
+          '';
+    });
+  }
+
+  List<Message> _mapToAnthropicMessages(List<ChatMessage> messages) {
+    return messages.map((message) {
+      switch (message.origin) {
+        case MessageOrigin.user:
+          if (message.attachments.isEmpty) {
+            return Message(
+              role: MessageRole.user,
+              content: MessageContent.text(message.text ?? ''),
+            );
+          }
+
+          final blocks = <Block>[
+            Block.text(text: message.text ?? ''),
+            for (final attachment in message.attachments)
+              if (attachment is ImageFileAttachment)
+                Block.image(
+                  source: ImageBlockSource(
+                    type: ImageBlockSourceType.base64,
+                    mediaType: switch (attachment.mimeType) {
+                      'image/jpeg' => ImageBlockSourceMediaType.imageJpeg,
+                      'image/png' => ImageBlockSourceMediaType.imagePng,
+                      'image/gif' => ImageBlockSourceMediaType.imageGif,
+                      'image/webp' => ImageBlockSourceMediaType.imageWebp,
+                      _ => throw LlmFailureException(
+                          'Unsupported image MIME type: ${attachment.mimeType}',
+                        ),
+                    },
+                    data: base64Encode(attachment.bytes),
+                  ),
+                )
+              else
+                throw LlmFailureException(
+                  'Unsupported attachment type: $attachment',
+                ),
+          ];
+
+          return Message(
+            role: MessageRole.user,
+            content: MessageContent.blocks(blocks),
+          );
+
+        case MessageOrigin.llm:
+          return Message(
+            role: MessageRole.assistant,
+            content: MessageContent.text(message.text ?? ''),
+          );
+      }
+    }).toList(growable: false);
+  }
+
+  @override
+  void dispose() {
+    _client.endSession();
+    super.dispose();
+  }
+}

--- a/lib/src/providers/providers.dart
+++ b/lib/src/providers/providers.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+export 'implementations/anthropic_provider.dart';
 export 'implementations/echo_provider.dart';
 export 'implementations/gemini_provider.dart';
 export 'implementations/vertex_provider.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
   flutter: '>=3.27.0-0'
 
 dependencies:
+  anthropic_sdk_dart: ^0.2.0+1
   cross_file: ^0.3.4+2
   file_selector: ^1.0.3
   firebase_vertexai: ^1.0.1


### PR DESCRIPTION
This PR adds support for [Anthropic](https://docs.anthropic.com/en/api/messages).

Not sure if you accept 3rd party providers. If not, this PR can be used as a reference for people to integrate Anthropic.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
