### PR TITLE
Add OpenAI, Anthropic and Ollama providers

### DIFF
--- a/lib/src/providers/implementations/anthropic_provider.dart
+++ b/lib/src/providers/implementations/anthropic_provider.dart
@@ -17,6 +17,12 @@ class AnthropicProvider extends LlmProvider with ChangeNotifier {
   /// Creates an Anthropic provider instance.
   ///
   /// The [apiKey] parameter is required for authentication with Anthropic's API.
+  ///
+  /// The [model] parameter specifies the LLM to use. You can find a list of available
+  /// models [here](https://docs.anthropic.com/en/docs/about-claude/models).
+  ///
+  /// For consuming Anthropic-compatible APIs, you can specify a custom [baseUrl], [headers],
+  /// and [queryParams].
   AnthropicProvider({
     required String apiKey,
     String? baseUrl,

--- a/lib/src/providers/implementations/anthropic_provider.dart
+++ b/lib/src/providers/implementations/anthropic_provider.dart
@@ -1,0 +1,163 @@
+import 'dart:convert';
+
+import 'package:anthropic_sdk_dart/anthropic_sdk_dart.dart';
+import 'package:flutter/foundation.dart';
+
+import '../../llm_exception.dart';
+import '../interface/attachments.dart';
+import '../interface/chat_message.dart';
+import '../interface/llm_provider.dart';
+import '../interface/message_origin.dart';
+
+/// A provider for Anthropic's language models (Claude).
+///
+/// This provider implements the [LlmProvider] interface to integrate Anthropic's
+/// models into the chat interface.
+class AnthropicProvider extends LlmProvider with ChangeNotifier {
+  /// Creates an Anthropic provider instance.
+  ///
+  /// The [apiKey] parameter is required for authentication with Anthropic's API.
+  AnthropicProvider({
+    required String apiKey,
+    String? baseUrl,
+    Map<String, String>? headers,
+    Map<String, String>? queryParams,
+    String model = 'claude-3-5-sonnet-latest',
+  })  : _client = AnthropicClient(
+          apiKey: apiKey,
+          baseUrl: baseUrl,
+          headers: {
+            'anthropic-dangerous-direct-browser-access': 'true',
+            if (headers != null) ...headers,
+          },
+          queryParams: queryParams,
+        ),
+        _model = model,
+        _history = [];
+
+  final AnthropicClient _client;
+  final String _model;
+  final List<ChatMessage> _history;
+
+  @override
+  Stream<String> generateStream(
+    String prompt, {
+    Iterable<Attachment> attachments = const [],
+  }) async* {
+    final messages = _mapToAnthropicMessages([
+      ChatMessage.user(prompt, attachments),
+    ]);
+
+    yield* _generateStream(messages);
+  }
+
+  @override
+  Stream<String> sendMessageStream(
+    String prompt, {
+    Iterable<Attachment> attachments = const [],
+  }) async* {
+    final userMessage = ChatMessage.user(prompt, attachments);
+    final llmMessage = ChatMessage.llm();
+    _history.addAll([userMessage, llmMessage]);
+
+    final messages = _mapToAnthropicMessages(_history);
+    final stream = _generateStream(messages);
+
+    // don't write this code if you're targeting the web until this is fixed:
+    // https://github.com/dart-lang/sdk/issues/47764
+    // await for (final chunk in stream) {
+    //   llmMessage.append(chunk);
+    //   yield chunk;
+    // }
+    yield* stream.map((chunk) {
+      llmMessage.append(chunk);
+      return chunk;
+    });
+
+    notifyListeners();
+  }
+
+  @override
+  Iterable<ChatMessage> get history => _history;
+
+  @override
+  set history(Iterable<ChatMessage> history) {
+    _history.clear();
+    _history.addAll(history);
+    notifyListeners();
+  }
+
+  Stream<String> _generateStream(List<Message> messages) async* {
+    final stream = _client.createMessageStream(
+      request: CreateMessageRequest(
+        model: Model.modelId(_model),
+        messages: messages,
+        maxTokens: 1024,
+      ),
+    );
+
+    yield* stream.map((event) {
+      return event.mapOrNull(
+            contentBlockDelta: (e) => e.delta.text,
+            error: (e) => throw LlmFailureException(e.error.message),
+          ) ??
+          '';
+    });
+  }
+
+  List<Message> _mapToAnthropicMessages(List<ChatMessage> messages) {
+    return messages.map((message) {
+      switch (message.origin) {
+        case MessageOrigin.user:
+          if (message.attachments.isEmpty) {
+            return Message(
+              role: MessageRole.user,
+              content: MessageContent.text(message.text ?? ''),
+            );
+          }
+
+          final blocks = <Block>[
+            Block.text(text: message.text ?? ''),
+            for (final attachment in message.attachments)
+              if (attachment is ImageFileAttachment)
+                Block.image(
+                  source: ImageBlockSource(
+                    type: ImageBlockSourceType.base64,
+                    mediaType: switch (attachment.mimeType) {
+                      'image/jpeg' => ImageBlockSourceMediaType.imageJpeg,
+                      'image/png' => ImageBlockSourceMediaType.imagePng,
+                      'image/gif' => ImageBlockSourceMediaType.imageGif,
+                      'image/webp' => ImageBlockSourceMediaType.imageWebp,
+                      _ => throw LlmFailureException(
+                          'Unsupported image MIME type: ${attachment.mimeType}',
+                        ),
+                    },
+                    data: base64Encode(attachment.bytes),
+                  ),
+                )
+              else
+                throw LlmFailureException(
+                  'Unsupported attachment type: $attachment',
+                ),
+          ];
+
+          return Message(
+            role: MessageRole.user,
+            content: MessageContent.blocks(blocks),
+          );
+
+        case MessageOrigin.llm:
+          return Message(
+            role: MessageRole.assistant,
+            content: MessageContent.text(message.text ?? ''),
+          );
+      }
+    }).toList(growable: false);
+  }
+
+  @override
+  void dispose() {
+    _client.endSession();
+    super.dispose();
+  }
+}

--- a/lib/src/providers/implementations/ollama_provider.dart
+++ b/lib/src/providers/implementations/ollama_provider.dart
@@ -1,0 +1,139 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:ollama_dart/ollama_dart.dart';
+
+import '../../llm_exception.dart';
+import '../interface/attachments.dart';
+import '../interface/chat_message.dart';
+import '../interface/llm_provider.dart';
+import '../interface/message_origin.dart';
+
+/// A provider for Ollama's language models.
+///
+/// This provider implements the [LlmProvider] interface to integrate Ollama's
+/// locally hosted models into the chat interface.
+class OllamaProvider extends LlmProvider with ChangeNotifier {
+  /// Creates an Ollama provider instance.
+  ///
+  /// The [model] parameter specifies which Ollama model to use (e.g., 'llama3.2-vision',
+  /// 'gemma, etc.). You can find a list of available models [here](https://ollama.com/search).
+  ///
+  /// The [baseUrl] defaults to 'http://localhost:11434/api' if not provided. You can also
+  /// specify custom [headers] and [queryParams] if needed.
+  OllamaProvider({
+    String? baseUrl,
+    Map<String, String>? headers,
+    Map<String, String>? queryParams,
+    required String model,
+  })  : _client = OllamaClient(
+          baseUrl: baseUrl,
+          headers: headers,
+          queryParams: queryParams,
+        ),
+        _model = model,
+        _history = [];
+
+  final OllamaClient _client;
+  final String _model;
+  final List<ChatMessage> _history;
+
+  @override
+  Stream<String> generateStream(
+    String prompt, {
+    Iterable<Attachment> attachments = const [],
+  }) async* {
+    final messages = _mapToOllamaMessages([
+      ChatMessage.user(prompt, attachments),
+    ]);
+
+    yield* _generateStream(messages);
+  }
+
+  @override
+  Stream<String> sendMessageStream(
+    String prompt, {
+    Iterable<Attachment> attachments = const [],
+  }) async* {
+    final userMessage = ChatMessage.user(prompt, attachments);
+    final llmMessage = ChatMessage.llm();
+    _history.addAll([userMessage, llmMessage]);
+
+    final messages = _mapToOllamaMessages(_history);
+    final stream = _generateStream(messages);
+
+    // don't write this code if you're targeting the web until this is fixed:
+    // https://github.com/dart-lang/sdk/issues/47764
+    // await for (final chunk in stream) {
+    //   llmMessage.append(chunk);
+    //   yield chunk;
+    // }
+    yield* stream.map((chunk) {
+      llmMessage.append(chunk);
+      return chunk;
+    });
+
+    notifyListeners();
+  }
+
+  @override
+  Iterable<ChatMessage> get history => _history;
+
+  @override
+  set history(Iterable<ChatMessage> history) {
+    _history.clear();
+    _history.addAll(history);
+    notifyListeners();
+  }
+
+  Stream<String> _generateStream(List<Message> messages) async* {
+    final stream = _client.generateChatCompletionStream(
+      request: GenerateChatCompletionRequest(
+        model: _model,
+        messages: messages,
+      ),
+    );
+
+    yield* stream.map((res) => res.message.content);
+  }
+
+  List<Message> _mapToOllamaMessages(List<ChatMessage> messages) {
+    return messages.map((message) {
+      switch (message.origin) {
+        case MessageOrigin.user:
+          if (message.attachments.isEmpty) {
+            return Message(
+              role: MessageRole.user,
+              content: message.text ?? '',
+            );
+          }
+
+          return Message(
+            role: MessageRole.user,
+            content: message.text ?? '',
+            images: [
+              for (final attachment in message.attachments)
+                if (attachment is ImageFileAttachment)
+                  base64Encode(attachment.bytes)
+                else
+                  throw LlmFailureException(
+                    'Unsupported attachment type: $attachment',
+                  ),
+            ],
+          );
+
+        case MessageOrigin.llm:
+          return Message(
+            role: MessageRole.assistant,
+            content: message.text ?? '',
+          );
+      }
+    }).toList(growable: false);
+  }
+
+  @override
+  void dispose() {
+    _client.endSession();
+    super.dispose();
+  }
+}

--- a/lib/src/providers/implementations/openai_provider.dart
+++ b/lib/src/providers/implementations/openai_provider.dart
@@ -115,7 +115,8 @@ class OpenAIProvider extends LlmProvider with ChangeNotifier {
         case MessageOrigin.user:
           if (message.attachments.isEmpty) {
             return ChatCompletionMessage.user(
-              content: ChatCompletionUserMessageContent.string(message.text ?? ''),
+              content:
+                  ChatCompletionUserMessageContent.string(message.text ?? ''),
             );
           }
 
@@ -125,11 +126,13 @@ class OpenAIProvider extends LlmProvider with ChangeNotifier {
               if (attachment is ImageFileAttachment)
                 ChatCompletionMessageContentPart.image(
                   imageUrl: ChatCompletionMessageImageUrl(
-                    url: 'data:${attachment.mimeType};base64,${base64Encode(attachment.bytes)}',
+                    url:
+                        'data:${attachment.mimeType};base64,${base64Encode(attachment.bytes)}',
                   ),
                 )
               else
-                throw LlmFailureException('Unsupported attachment type: $attachment'),
+                throw LlmFailureException(
+                    'Unsupported attachment type: $attachment'),
           ];
           return ChatCompletionMessage.user(
             content: ChatCompletionUserMessageContent.parts(parts),

--- a/lib/src/providers/implementations/openai_provider.dart
+++ b/lib/src/providers/implementations/openai_provider.dart
@@ -1,0 +1,147 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:openai_dart/openai_dart.dart';
+
+import '../../llm_exception.dart';
+import '../interface/attachments.dart';
+import '../interface/chat_message.dart';
+import '../interface/llm_provider.dart';
+import '../interface/message_origin.dart';
+
+/// A provider for OpenAI's language models.
+///
+/// This provider implements the [LlmProvider] interface to integrate OpenAI's
+/// models into the chat interface.
+class OpenAIProvider extends LlmProvider with ChangeNotifier {
+  /// Creates an OpenAI provider instance.
+  ///
+  /// The [apiKey] parameter is required for authentication with OpenAI's API.
+  /// Optionally, [organization] can be specified for users belonging to multiple
+  /// organizations.
+  OpenAIProvider({
+    required String apiKey,
+    String? organization,
+    String? baseUrl,
+    Map<String, String>? headers,
+    Map<String, String>? queryParams,
+    String model = 'gpt-4o',
+  })  : _client = OpenAIClient(
+          apiKey: apiKey,
+          organization: organization,
+          baseUrl: baseUrl,
+          headers: headers,
+          queryParams: queryParams,
+        ),
+        _model = model,
+        _history = [];
+
+  final OpenAIClient _client;
+  final String _model;
+  final List<ChatMessage> _history;
+
+  @override
+  Stream<String> generateStream(
+    String prompt, {
+    Iterable<Attachment> attachments = const [],
+  }) async* {
+    final messages = _mapToOpenAIMessages([
+      ChatMessage.user(prompt, attachments),
+    ]);
+
+    yield* _generateStream(messages);
+  }
+
+  @override
+  Stream<String> sendMessageStream(
+    String prompt, {
+    Iterable<Attachment> attachments = const [],
+  }) async* {
+    final userMessage = ChatMessage.user(prompt, attachments);
+    final llmMessage = ChatMessage.llm();
+    _history.addAll([userMessage, llmMessage]);
+
+    final messages = _mapToOpenAIMessages(_history);
+    final stream = _generateStream(messages);
+
+    // don't write this code if you're targeting the web until this is fixed:
+    // https://github.com/dart-lang/sdk/issues/47764
+    // await for (final chunk in stream) {
+    //   llmMessage.append(chunk);
+    //   yield chunk;
+    // }
+    yield* stream.map((chunk) {
+      llmMessage.append(chunk);
+      return chunk;
+    });
+
+    // notify listeners that the history has changed when response is complete
+    notifyListeners();
+  }
+
+  @override
+  Iterable<ChatMessage> get history => _history;
+
+  @override
+  set history(Iterable<ChatMessage> history) {
+    _history.clear();
+    _history.addAll(history);
+    notifyListeners();
+  }
+
+  Stream<String> _generateStream(List<ChatCompletionMessage> messages) async* {
+    final stream = _client.createChatCompletionStream(
+      request: CreateChatCompletionRequest(
+        model: ChatCompletionModel.modelId(_model),
+        messages: messages,
+      ),
+    );
+
+    yield* stream
+        .map((res) => res.choices.firstOrNull?.delta.content)
+        .where((content) => content != null)
+        .cast<String>();
+  }
+
+  List<ChatCompletionMessage> _mapToOpenAIMessages(List<ChatMessage> messages) {
+    return messages.map((message) {
+      switch (message.origin) {
+        case MessageOrigin.user:
+          if (message.attachments.isEmpty) {
+            return ChatCompletionMessage.user(
+              content:
+                  ChatCompletionUserMessageContent.string(message.text ?? ''),
+            );
+          }
+
+          final parts = [
+            ChatCompletionMessageContentPart.text(text: message.text ?? ''),
+            for (final attachment in message.attachments)
+              if (attachment is ImageFileAttachment)
+                ChatCompletionMessageContentPart.image(
+                  imageUrl: ChatCompletionMessageImageUrl(
+                    url:
+                        'data:${attachment.mimeType};base64,${base64Encode(attachment.bytes)}',
+                  ),
+                )
+              else
+                throw LlmFailureException(
+                    'Unsupported attachment type: $attachment'),
+          ];
+          return ChatCompletionMessage.user(
+            content: ChatCompletionUserMessageContent.parts(parts),
+          );
+        case MessageOrigin.llm:
+          return ChatCompletionMessage.assistant(
+            content: message.text ?? '',
+          );
+      }
+    }).toList(growable: false);
+  }
+
+  @override
+  void dispose() {
+    _client.endSession();
+    super.dispose();
+  }
+}

--- a/lib/src/providers/implementations/openai_provider.dart
+++ b/lib/src/providers/implementations/openai_provider.dart
@@ -19,6 +19,12 @@ class OpenAIProvider extends LlmProvider with ChangeNotifier {
   /// The [apiKey] parameter is required for authentication with OpenAI's API.
   /// Optionally, [organization] can be specified for users belonging to multiple
   /// organizations.
+  ///
+  /// The [model] parameter specifies the LLM to use. You can find a list of available
+  /// models [here](https://platform.openai.com/docs/models).
+  ///
+  /// For consuming OpenAI-compatible APIs, you can specify a custom [baseUrl], [headers],
+  /// and [queryParams].
   OpenAIProvider({
     required String apiKey,
     String? organization,
@@ -109,8 +115,7 @@ class OpenAIProvider extends LlmProvider with ChangeNotifier {
         case MessageOrigin.user:
           if (message.attachments.isEmpty) {
             return ChatCompletionMessage.user(
-              content:
-                  ChatCompletionUserMessageContent.string(message.text ?? ''),
+              content: ChatCompletionUserMessageContent.string(message.text ?? ''),
             );
           }
 
@@ -120,13 +125,11 @@ class OpenAIProvider extends LlmProvider with ChangeNotifier {
               if (attachment is ImageFileAttachment)
                 ChatCompletionMessageContentPart.image(
                   imageUrl: ChatCompletionMessageImageUrl(
-                    url:
-                        'data:${attachment.mimeType};base64,${base64Encode(attachment.bytes)}',
+                    url: 'data:${attachment.mimeType};base64,${base64Encode(attachment.bytes)}',
                   ),
                 )
               else
-                throw LlmFailureException(
-                    'Unsupported attachment type: $attachment'),
+                throw LlmFailureException('Unsupported attachment type: $attachment'),
           ];
           return ChatCompletionMessage.user(
             content: ChatCompletionUserMessageContent.parts(parts),

--- a/lib/src/providers/providers.dart
+++ b/lib/src/providers/providers.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+export 'implementations/anthropic_provider.dart';
 export 'implementations/echo_provider.dart';
 export 'implementations/gemini_provider.dart';
 export 'implementations/openai_provider.dart';

--- a/lib/src/providers/providers.dart
+++ b/lib/src/providers/providers.dart
@@ -4,6 +4,7 @@
 
 export 'implementations/echo_provider.dart';
 export 'implementations/gemini_provider.dart';
+export 'implementations/openai_provider.dart';
 export 'implementations/vertex_provider.dart';
 export 'interface/attachments.dart';
 export 'interface/chat_message.dart';

--- a/lib/src/providers/providers.dart
+++ b/lib/src/providers/providers.dart
@@ -5,6 +5,7 @@
 export 'implementations/anthropic_provider.dart';
 export 'implementations/echo_provider.dart';
 export 'implementations/gemini_provider.dart';
+export 'implementations/ollama_provider.dart';
 export 'implementations/openai_provider.dart';
 export 'implementations/vertex_provider.dart';
 export 'interface/attachments.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
   google_generative_ai: ^0.4.3
   image_picker: ^1.1.2
   mime: ^2.0.0
+  openai_dart: ^0.4.5
   universal_platform: ^1.1.0
   uuid: ^4.4.2
   waveform_recorder: ^1.3.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,11 +29,12 @@ dependencies:
   google_generative_ai: ^0.4.3
   image_picker: ^1.1.2
   mime: ^2.0.0
+  ollama_dart: ^0.2.2+1
   openai_dart: ^0.4.5
   universal_platform: ^1.1.0
   uuid: ^4.4.2
   waveform_recorder: ^1.3.0
-  
+
 dev_dependencies:
   flutter_lints: ^5.0.0
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
+  anthropic_sdk_dart: ^0.2.0+1
   cross_file: ^0.3.4+2
   file_selector: ^1.0.3
   firebase_vertexai: ^1.0.1


### PR DESCRIPTION
This PR adds support for [OpenAI](https://platform.openai.com/docs/guides/text-generation), [Anthropic](https://docs.anthropic.com/en/api/messages) and [Ollama](https://ollama.com/).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
