### PR TITLE
Remove dependency on `package:gap`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.6.8-wip
 
 * Require Dart 3.5 or later.
-* 
+* Remove dependency on `package:gap`.
 
 ## 0.6.7
 

--- a/example/lib/demo/api_key_page.dart
+++ b/example/lib/demo/api_key_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:gap/gap.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class GeminiApiKeyPage extends StatefulWidget {
@@ -57,7 +56,7 @@ class _GeminiApiKeyPageState extends State<GeminiApiKeyPage> {
                     child: Text('(or copy the URL above by tapping HERE)'),
                   ),
                 ),
-                const Gap(16),
+                const SizedBox(height: 16),
                 const Text('Paste your API key here:'),
                 SizedBox(
                   width: 300,
@@ -74,7 +73,7 @@ class _GeminiApiKeyPageState extends State<GeminiApiKeyPage> {
                         : null,
                   ),
                 ),
-                const Gap(16),
+                const SizedBox(height: 16),
                 ElevatedButton(
                   onPressed: _isValidApiKey()
                       ? () => widget.onApiKey(_controller.text)

--- a/example/lib/recipes/pages/edit_recipe_page.dart
+++ b/example/lib/recipes/pages/edit_recipe_page.dart
@@ -6,7 +6,6 @@ import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_ai_toolkit/flutter_ai_toolkit.dart';
-import 'package:gap/gap.dart';
 import 'package:go_router/go_router.dart';
 import 'package:google_generative_ai/google_generative_ai.dart';
 import 'package:uuid/uuid.dart';
@@ -150,7 +149,7 @@ When you generate a recipe, you should generate a JSON object.
                   ),
                   maxLines: null,
                 ),
-                const Gap(16),
+                const SizedBox(height: 16),
                 OverflowBar(
                   spacing: 16,
                   children: [
@@ -210,9 +209,9 @@ When you generate a recipe, you should generate a JSON object.
           title: Text(recipe.title),
           content: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
+            spacing: 16,
             children: [
               const Text('Modifications:'),
-              const Gap(16),
               Text(_wrapText(modifications)),
             ],
           ),

--- a/example/lib/recipes/views/recipe_content_view.dart
+++ b/example/lib/recipes/views/recipe_content_view.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
 
 import '../data/recipe_data.dart';
 
@@ -25,18 +24,18 @@ class RecipeContentView extends StatelessWidget {
                   ? SingleChildScrollView(
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
+                        spacing: 16,
                         children: [
                           _RecipeIngredientsView(recipe),
-                          const Gap(16),
                           _RecipeInstructionsView(recipe),
                         ],
                       ),
                     )
                   : Row(
                       crossAxisAlignment: CrossAxisAlignment.start,
+                      spacing: 16,
                       children: [
                         Expanded(child: _RecipeIngredientsView(recipe)),
-                        const Gap(16),
                         Expanded(child: _RecipeInstructionsView(recipe)),
                       ],
                     ),

--- a/example/lib/recipes/views/recipe_response_view.dart
+++ b/example/lib/recipes/views/recipe_response_view.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
-import 'package:gap/gap.dart';
 
 import '../data/recipe_data.dart';
 import '../data/recipe_repository.dart';
@@ -35,7 +34,6 @@ class RecipeResponseView extends StatelessWidget {
         // extract the recipe
         final json = recipeWithText['recipe'] as Map<String, dynamic>;
         final recipe = Recipe.fromJson(json);
-        children.add(const Gap(16));
         children.add(Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -46,12 +44,10 @@ class RecipeResponseView extends StatelessWidget {
         ));
 
         // add a button to add the recipe to the list
-        children.add(const Gap(16));
         children.add(OutlinedButton(
           onPressed: () => RecipeRepository.addNewRecipe(recipe),
           child: const Text('Add Recipe'),
         ));
-        children.add(const Gap(16));
       }
     } catch (e) {
       debugPrint('Error parsing response: $e');
@@ -74,6 +70,7 @@ class RecipeResponseView extends StatelessWidget {
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
+      spacing: 16,
       children: children,
     );
   }

--- a/example/lib/recipes/views/recipe_view.dart
+++ b/example/lib/recipes/views/recipe_view.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
 
 import '../data/recipe_data.dart';
 import 'recipe_content_view.dart';
@@ -52,7 +51,7 @@ class RecipeView extends StatelessWidget {
                     ],
                   ),
                 ),
-                const Gap(16),
+                const SizedBox(height: 16),
               ],
             ),
           ],

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -18,7 +18,6 @@ dependencies:
   firebase_vertexai: ^1.0.1
   shared_preferences: ^2.3.2
   url_launcher: ^6.3.0
-  gap: ^3.0.1
   go_router: ^14.2.8
   uuid: ^4.5.1
   path: ^1.9.0

--- a/lib/src/views/attachment_view/file_attatchment_view.dart
+++ b/lib/src/views/attachment_view/file_attatchment_view.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:flutter/widgets.dart';
-import 'package:gap/gap.dart';
 
 import '../../chat_view_model/chat_view_model_client.dart';
 import '../../providers/interface/attachments.dart';
@@ -37,6 +36,7 @@ class FileAttachmentView extends StatelessWidget {
             decoration: attachmentStyle.decoration,
             child: Row(
               mainAxisSize: MainAxisSize.min,
+              spacing: 8,
               children: [
                 Container(
                   height: 64,
@@ -48,7 +48,6 @@ class FileAttachmentView extends StatelessWidget {
                     size: 24,
                   ),
                 ),
-                const Gap(8),
                 Flexible(
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/src/views/chat_input/chat_input.dart
+++ b/lib/src/views/chat_input/chat_input.dart
@@ -5,7 +5,6 @@
 import 'package:file_selector/file_selector.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
-import 'package:gap/gap.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:waveform_recorder/waveform_recorder.dart';
 
@@ -149,7 +148,7 @@ class _ChatInputState extends State<ChatInput> {
                   attachments: _attachments,
                   onRemove: onRemoveAttachment,
                 ),
-                if (_attachments.isNotEmpty) const Gap(6),
+                if (_attachments.isNotEmpty) const SizedBox(height: 6),
                 ValueListenableBuilder(
                   valueListenable: _textController,
                   builder: (context, value, child) => ListenableBuilder(

--- a/lib/src/views/chat_input/editing_indicator.dart
+++ b/lib/src/views/chat_input/editing_indicator.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/widgets.dart';
-import 'package:gap/gap.dart';
 
 import '../../styles/action_button_style.dart';
 import '../../styles/toolkit_text_styles.dart';
@@ -36,6 +35,7 @@ class EditingIndicator extends StatelessWidget {
         child: Row(
           mainAxisAlignment: MainAxisAlignment.end,
           crossAxisAlignment: CrossAxisAlignment.end,
+          spacing: 6,
           children: [
             Text(
               'Editing',
@@ -43,7 +43,6 @@ class EditingIndicator extends StatelessWidget {
                 color: invertColor(cancelButtonStyle.iconColor),
               ),
             ),
-            const Gap(6),
             ActionButton(
               onPressed: onCancelEdit,
               style: cancelButtonStyle,

--- a/lib/src/views/chat_message_view/hovering_buttons.dart
+++ b/lib/src/views/chat_message_view/hovering_buttons.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:flutter/widgets.dart';
-import 'package:gap/gap.dart';
 
 import '../../styles/llm_chat_view_style.dart';
 import '../../utility.dart';
@@ -66,6 +65,7 @@ class HoveringButtons extends StatelessWidget {
                           right: isUserMessage ? 0 : null,
                           left: isUserMessage ? null : 32,
                           child: Row(
+                            spacing: 6,
                             children: [
                               if (onEdit != null)
                                 GestureDetector(
@@ -78,7 +78,6 @@ class HoveringButtons extends StatelessWidget {
                                     ),
                                   ),
                                 ),
-                              const Gap(6),
                               GestureDetector(
                                 onTap: () => unawaited(
                                   copyToClipboard(context, clipboardText!),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,6 @@ dependencies:
   flutter_context_menu: ^0.2.0
   flutter_markdown: ^0.7.4+3
   flutter_picture_taker: ^0.2.0
-  gap: ^3.0.1
   google_fonts: ^6.2.1
   google_generative_ai: ^0.4.3
   image_picker: ^1.1.2
@@ -31,7 +30,7 @@ dependencies:
   universal_platform: ^1.1.0
   uuid: ^4.4.2
   waveform_recorder: ^1.3.0
-  
+
 dev_dependencies:
   flutter_lints: ^5.0.0
   flutter_test:


### PR DESCRIPTION
It seems developers have some concerns about the amount of dependencies. Too many dependencies can also make a successful or at least up-to-date package resolution harder. This PR begins work towards improving the situation by removing the dependency on `package:gap`.