### PR TITLE
Export package exceptions

### DIFF
--- a/lib/flutter_ai_toolkit.dart
+++ b/lib/flutter_ai_toolkit.dart
@@ -14,6 +14,7 @@
 /// - Chat UI: Ready-to-use widgets for displaying chat interfaces.
 library;
 
+export 'src/llm_exception.dart';
 export 'src/providers/interface/chat_message.dart';
 export 'src/providers/providers.dart';
 export 'src/styles/styles.dart';


### PR DESCRIPTION
The custom exceptions that the package uses are currently not exported, so they cannot be used when implementing custom providers.

This PR exposes them.