### PR TITLE
Do not update patch versions for `dependabot/github-actions`.

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,6 +6,11 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    # Updating patch versions for "github-actions" is too chatty.
+    # See https://github.com/flutter/flutter/issues/158350.
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
   # Pub ecosystem.
   - package-ecosystem: "pub"
     versioning-strategy: "increase-if-necessary"


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/158350.