### PR TITLE
handle pub publish warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,6 @@ migrate_working_dir/
 .dart_tool/
 build/
 example/.env
-example/lib/firebase_options.dart
 example/firebase.json
 example/.firebaserc
 example/android/app/google-services.json

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -44,7 +44,3 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
-
-# custom
-gemini_api_key.dart
-firebase_options.dart


### PR DESCRIPTION
Remove the files from `.gitignore` that cause `flutter pub publish` warnings. Since the files are checked into the repo anyway, having them in the `.gitignore` files don't matter anyway, so might as well remove the warnings.

## issues fixed by this PR
- https://github.com/flutter/ai/issues/49

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.