### PR TITLE
dismiss mobile vkb on tap outside input

### DIFF
--- a/lib/src/views/llm_chat_view/llm_chat_view.dart
+++ b/lib/src/views/llm_chat_view/llm_chat_view.dart
@@ -166,48 +166,54 @@ class _LlmChatViewState extends State<LlmChatView>
       builder:
           (context, child) => ChatViewModelProvider(
             viewModel: widget.viewModel,
-            child: Container(
-              color: chatStyle.backgroundColor,
-              child: Column(
-                children: [
-                  Expanded(
-                    child: Stack(
-                      children: [
-                        ChatHistoryView(
-                          // can only edit if we're not waiting on the LLM or if
-                          // we're not already editing an LLM response
-                          onEditMessage:
-                              _pendingPromptResponse == null &&
-                                      _associatedResponse == null
-                                  ? _onEditMessage
-                                  : null,
-                        ),
-                        if (widget.suggestions.isNotEmpty &&
-                            widget.viewModel.provider.history.isEmpty)
-                          Align(
-                            alignment: Alignment.topCenter,
-                            child: ChatSuggestionsView(
-                              suggestions: widget.suggestions,
-                              onSelectSuggestion: _onSelectSuggestion,
-                            ),
+            child: GestureDetector(
+              onTap: () {
+                // Dismiss keyboard when tapping anywhere in the view
+                FocusScope.of(context).unfocus();
+              },
+              child: Container(
+                color: chatStyle.backgroundColor,
+                child: Column(
+                  children: [
+                    Expanded(
+                      child: Stack(
+                        children: [
+                          ChatHistoryView(
+                            // can only edit if we're not waiting on the LLM or if
+                            // we're not already editing an LLM response
+                            onEditMessage:
+                                _pendingPromptResponse == null &&
+                                        _associatedResponse == null
+                                    ? _onEditMessage
+                                    : null,
                           ),
-                      ],
+                          if (widget.suggestions.isNotEmpty &&
+                              widget.viewModel.provider.history.isEmpty)
+                            Align(
+                              alignment: Alignment.topCenter,
+                              child: ChatSuggestionsView(
+                                suggestions: widget.suggestions,
+                                onSelectSuggestion: _onSelectSuggestion,
+                              ),
+                            ),
+                        ],
+                      ),
                     ),
-                  ),
-                  ChatInput(
-                    initialMessage: _initialMessage,
-                    onCancelEdit:
-                        _associatedResponse != null ? _onCancelEdit : null,
-                    onSendMessage: _onSendMessage,
-                    onCancelMessage:
-                        _pendingPromptResponse == null
-                            ? null
-                            : _onCancelMessage,
-                    onTranslateStt: _onTranslateStt,
-                    onCancelStt:
-                        _pendingSttResponse == null ? null : _onCancelStt,
-                  ),
-                ],
+                    ChatInput(
+                      initialMessage: _initialMessage,
+                      onCancelEdit:
+                          _associatedResponse != null ? _onCancelEdit : null,
+                      onSendMessage: _onSendMessage,
+                      onCancelMessage:
+                          _pendingPromptResponse == null
+                              ? null
+                              : _onCancelMessage,
+                      onTranslateStt: _onTranslateStt,
+                      onCancelStt:
+                          _pendingSttResponse == null ? null : _onCancelStt,
+                    ),
+                  ],
+                ),
               ),
             ),
           ),


### PR DESCRIPTION
Fixes an issue with being unable to dismiss the virtual keyboard on mobile.

## issues fixed by this PR
- https://github.com/flutter/ai/issues/55

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.