### PR TITLE
Create publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,22 @@
+name: Publish to pub.dev
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+
+jobs:
+  publish:
+    name: Publish to pub.dev
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dart-lang/setup-dart@v1
+      - uses: subosito/flutter-action@e938fdf56512cc96ef2f93601a5a40bde3801046
+        with:
+          channel: 'stable'
+      - run: flutter pub get
+      - name: Publish
+        run: flutter pub publish --force


### PR DESCRIPTION
Enabled automated publishing to pub.dev

Once this has landed pushing a tag `v{{version}}` should publish the package to pub.dev

Such tags can be created through the UI on github.com, by creating "releases".