### PR TITLE
fix #95: Image Attachment Disappears After Audio Recording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.8.1
+
+* fixed [#95](https://github.com/flutter/ai/issues/95): Image Attachment
+  Disappears After Audio Recording
+
 ## 0.8.0
 * fixed [#90](https://github.com/flutter/ai/issues/90): Input box
   shrinks unexpectedly when clicking file attachment button – customization not

--- a/lib/src/views/chat_input/chat_input.dart
+++ b/lib/src/views/chat_input/chat_input.dart
@@ -57,8 +57,10 @@ class ChatInput extends StatefulWidget {
 
   /// Callback function triggered when speech-to-text translation is requested.
   ///
-  /// Takes an [XFile] representing the audio file to be translated.
-  final void Function(XFile file) onTranslateStt;
+  /// Takes an [XFile] representing the audio file to be translated and the
+  /// current attachments.
+  final void Function(XFile file, Iterable<Attachment> attachments)
+  onTranslateStt;
 
   /// The initial message to populate the input field, if any.
   final ChatMessage? initialMessage;
@@ -249,8 +251,8 @@ class _ChatInputState extends State<ChatInput> {
       return;
     }
 
-    // will come back as initialMessage
-    widget.onTranslateStt(file);
+    // Pass current attachments to onTranslateStt
+    widget.onTranslateStt(file, List.from(_attachments));
   }
 
   void onAttachments(Iterable<Attachment> attachments) {

--- a/lib/src/views/llm_chat_view/llm_chat_view.dart
+++ b/lib/src/views/llm_chat_view/llm_chat_view.dart
@@ -277,7 +277,10 @@ class _LlmChatViewState extends State<LlmChatView>
     });
   }
 
-  Future<void> _onTranslateStt(XFile file) async {
+  Future<void> _onTranslateStt(
+    XFile file,
+    Iterable<Attachment> currentAttachments,
+  ) async {
     assert(widget.enableVoiceNotes);
     _initialMessage = null;
     _associatedResponse = null;
@@ -297,7 +300,9 @@ class _LlmChatViewState extends State<LlmChatView>
         attachments: attachments,
       ),
       onUpdate: (text) => response += text,
-      onDone: (error) async => _onSttDone(error, response, file),
+      onDone:
+          (error) async =>
+              _onSttDone(error, response, file, currentAttachments),
     );
 
     setState(() {});
@@ -307,10 +312,12 @@ class _LlmChatViewState extends State<LlmChatView>
     LlmException? error,
     String response,
     XFile file,
+    Iterable<Attachment> attachments,
   ) async {
     assert(_pendingSttResponse != null);
     setState(() {
-      _initialMessage = ChatMessage.user(response, []);
+      // Preserve any existing attachments from the current input
+      _initialMessage = ChatMessage.user(response, attachments);
       _pendingSttResponse = null;
     });
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_ai_toolkit
 description: >-
   A set of AI chat-related widgets for Flutter apps targeting
   mobile, desktop, and web.
-version: 0.8.0
+version: 0.8.1
 repository: https://github.com/flutter/ai
 
 topics:


### PR DESCRIPTION
Fixes the case that an audio recording clears out the existing attachments, if there are any.

## issues fixed by this PR:
- #95: Image Attachment Disappears After Audio Recording

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.