### PR TITLE
feat: add autofocus parameter

### DIFF
--- a/lib/src/views/llm_chat_view/llm_chat_view.dart
+++ b/lib/src/views/llm_chat_view/llm_chat_view.dart
@@ -182,54 +182,55 @@ class _LlmChatViewState extends State<LlmChatView>
     final chatStyle = LlmChatViewStyle.resolve(widget.viewModel.style);
     return ListenableBuilder(
       listenable: widget.viewModel.provider,
-      builder: (context, child) => ChatViewModelProvider(
-        viewModel: widget.viewModel,
-        child: GestureDetector(
-          onTap: () {
-            // Dismiss keyboard when tapping anywhere in the view
-            FocusScope.of(context).unfocus();
-          },
-          child: Container(
-            color: chatStyle.backgroundColor,
-            child: Column(
-              children: [
-                Expanded(
-                  child: Stack(
-                    children: [
-                      ChatHistoryView(
-                        // can only edit if we're not waiting on the LLM or if
-                        // we're not already editing an LLM response
-                        onEditMessage:
-                            _pendingPromptResponse == null &&
-                                _associatedResponse == null
-                            ? _onEditMessage
-                            : null,
-                        onSelectSuggestion: _onSelectSuggestion,
+      builder:
+          (context, child) => ChatViewModelProvider(
+            viewModel: widget.viewModel,
+            child: GestureDetector(
+              onTap: () {
+                // Dismiss keyboard when tapping anywhere in the view
+                FocusScope.of(context).unfocus();
+              },
+              child: Container(
+                color: chatStyle.backgroundColor,
+                child: Column(
+                  children: [
+                    Expanded(
+                      child: Stack(
+                        children: [
+                          ChatHistoryView(
+                            // can only edit if we're not waiting on the LLM or if
+                            // we're not already editing an LLM response
+                            onEditMessage:
+                                _pendingPromptResponse == null &&
+                                        _associatedResponse == null
+                                    ? _onEditMessage
+                                    : null,
+                            onSelectSuggestion: _onSelectSuggestion,
+                          ),
+                        ],
                       ),
-                    ],
-                  ),
+                    ),
+                    ChatInput(
+                      initialMessage: _initialMessage,
+                      autofocus:
+                          widget.autofocus ??
+                          widget.viewModel.suggestions.isEmpty,
+                      onCancelEdit:
+                          _associatedResponse != null ? _onCancelEdit : null,
+                      onSendMessage: _onSendMessage,
+                      onCancelMessage:
+                          _pendingPromptResponse == null
+                              ? null
+                              : _onCancelMessage,
+                      onTranslateStt: _onTranslateStt,
+                      onCancelStt:
+                          _pendingSttResponse == null ? null : _onCancelStt,
+                    ),
+                  ],
                 ),
-                ChatInput(
-                  initialMessage: _initialMessage,
-                  autofocus:
-                      widget.autofocus ?? widget.viewModel.suggestions.isEmpty,
-                  onCancelEdit: _associatedResponse != null
-                      ? _onCancelEdit
-                      : null,
-                  onSendMessage: _onSendMessage,
-                  onCancelMessage: _pendingPromptResponse == null
-                      ? null
-                      : _onCancelMessage,
-                  onTranslateStt: _onTranslateStt,
-                  onCancelStt: _pendingSttResponse == null
-                      ? null
-                      : _onCancelStt,
-                ),
-              ],
+              ),
             ),
           ),
-        ),
-      ),
     );
   }
 
@@ -309,8 +310,9 @@ class _LlmChatViewState extends State<LlmChatView>
         attachments: attachments,
       ),
       onUpdate: (text) => response += text,
-      onDone: (error) async =>
-          _onSttDone(error, response, file, currentAttachments),
+      onDone:
+          (error) async =>
+              _onSttDone(error, response, file, currentAttachments),
     );
 
     setState(() {});

--- a/test/suggestions_test.dart
+++ b/test/suggestions_test.dart
@@ -6,7 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('Suggestions - Welcome message overlap tests', () {
-    Widget materialApp(int suggestionsCount) => MaterialApp(
+    Widget materialApp(int suggestionsCount, {bool? autofocus}) => MaterialApp(
       home: Scaffold(
         appBar: AppBar(title: const Text('Title')),
         body: LlmChatView(
@@ -17,6 +17,7 @@ void main() {
             (index) => 'Suggestion sample ${index + 1}',
           ),
           provider: EchoProvider(),
+          autofocus: autofocus,
         ),
       ),
     );
@@ -67,6 +68,32 @@ void main() {
       expect(suggestionsView, findsOne);
 
       // TextField must be focused now
+      expect((tester.widget<TextField>(textField)).focusNode?.hasFocus, true);
+    });
+    testWidgets('force autofocus false even if no suggestions provided', (
+      tester,
+    ) async {
+      // No suggestions provided, but autofocus is set to false
+      await tester.pumpWidget(materialApp(0, autofocus: false));
+
+      // ChatTextField must be autofocus false and TextField must not be focused
+      // because parameter is set to false
+      final chatTextField = find.byType(ChatTextField);
+      final textField = find.byType(TextField);
+      expect((tester.widget<ChatTextField>(chatTextField)).autofocus, false);
+      expect((tester.widget<TextField>(textField)).focusNode?.hasFocus, false);
+    });
+    testWidgets('force autofocus true even if suggestions provided', (
+      tester,
+    ) async {
+      // Suggestions provided, but autofocus is set to true
+      await tester.pumpWidget(materialApp(40, autofocus: true));
+
+      // ChatTextField must be autofocus true and TextField must be focused
+      // because parameter is set to true
+      final chatTextField = find.byType(ChatTextField);
+      final textField = find.byType(TextField);
+      expect((tester.widget<ChatTextField>(chatTextField)).autofocus, true);
       expect((tester.widget<TextField>(textField)).focusNode?.hasFocus, true);
     });
     testWidgets('Welcome message with a lot of suggestions allowing scroll', (


### PR DESCRIPTION
This PR allows to disable autofocus in the `LlmChatView`.

Currently, the chat input will be focused automatically, to avoid that you can set the list of suggestions. This PR introduces an optional `autofocus` parameter to override that functionality and force the autofocus on or off.

Closes: #133 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
