### PR TITLE
work-around for MenuAnchor not handling soft keyboard properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ example/lib/echo.dart
 .flutter-plugins
 .flutter-plugins-dependencies
 .vscode/settings.json
+AGENT.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## 0.9.2
 
 - fix [#137](https://github.com/flutter/ai/issues/137): Link Attachments are not
-  supported 
+  supported
+
+- fix [#112](https://github.com/flutter/ai/issues/112): attachments pop-up menu
+  appears behind soft keyboard on mobile
 
 ## 0.9.1
 * fix [#96](https://github.com/flutter/ai/issues/96): input field overlap issue

--- a/lib/src/views/chat_input/attachments_action_bar.dart
+++ b/lib/src/views/chat_input/attachments_action_bar.dart
@@ -8,6 +8,7 @@ import 'package:file_selector/file_selector.dart';
 import 'package:flutter/material.dart'
     show MenuAnchor, MenuItemButton, MenuStyle;
 import 'package:flutter/widgets.dart';
+import 'package:flutter_ai_toolkit/src/utility.dart';
 import 'package:image_picker/image_picker.dart';
 
 import '../../chat_view_model/chat_view_model_client.dart';
@@ -44,72 +45,60 @@ class _AttachmentActionBarState extends State<AttachmentActionBar> {
     _canCamera = canTakePhoto();
   }
 
-  /// Estimates the height of a MenuItemButton based on Material Design specs
-  double _estimateMenuItemHeight(BuildContext context) {
-    // From MenuAnchor source: minimum height is 48.0
-    // Add some padding for safety
-    return 48.0 + 8.0; // 56.0 total per item
-  }
-
-  /// Builds the menu items list to avoid duplication
-  List<Widget> _buildMenuItems(LlmChatViewStyle chatStyle) {
-    return [
-      if (_canCamera)
-        MenuItemButton(
-          leadingIcon: Icon(
-            chatStyle.cameraButtonStyle!.icon!,
-            color: chatStyle.cameraButtonStyle!.iconColor,
-          ),
-          onPressed: () => _onCamera(),
-          child: Text(
-            chatStyle.cameraButtonStyle!.text!,
-            style: chatStyle.cameraButtonStyle!.textStyle,
-          ),
-        ),
-      MenuItemButton(
-        leadingIcon: Icon(
-          chatStyle.galleryButtonStyle!.icon!,
-          color: chatStyle.galleryButtonStyle!.iconColor,
-        ),
-        onPressed: () => _onGallery(),
-        child: Text(
-          chatStyle.galleryButtonStyle!.text!,
-          style: chatStyle.galleryButtonStyle!.textStyle,
-        ),
-      ),
-      MenuItemButton(
-        leadingIcon: Icon(
-          chatStyle.attachFileButtonStyle!.icon!,
-          color: chatStyle.attachFileButtonStyle!.iconColor,
-        ),
-        onPressed: () => _onFile(),
-        child: Text(
-          chatStyle.attachFileButtonStyle!.text!,
-          style: chatStyle.attachFileButtonStyle!.textStyle,
-        ),
-      ),
-    ];
-  }
-
   @override
   Widget build(BuildContext context) => ChatViewModelClient(
     builder: (context, viewModel, child) {
       final chatStyle = LlmChatViewStyle.resolve(viewModel.style);
-      final menuItems = _buildMenuItems(chatStyle);
-
-      // Calculate menu height based on actual number of items
-      final double itemHeight = _estimateMenuItemHeight(context);
-      final double menuPadding =
-          16.0; // Menu vertical padding from MenuAnchor source
-      final double estimatedMenuHeight =
-          (menuItems.length * itemHeight) + menuPadding;
+      final menuItems = [
+        if (_canCamera)
+          MenuItemButton(
+            leadingIcon: Icon(
+              chatStyle.cameraButtonStyle!.icon!,
+              color: chatStyle.cameraButtonStyle!.iconColor,
+            ),
+            onPressed: () => _onCamera(),
+            child: Text(
+              chatStyle.cameraButtonStyle!.text!,
+              style: chatStyle.cameraButtonStyle!.textStyle,
+            ),
+          ),
+        MenuItemButton(
+          leadingIcon: Icon(
+            chatStyle.galleryButtonStyle!.icon!,
+            color: chatStyle.galleryButtonStyle!.iconColor,
+          ),
+          onPressed: () => _onGallery(),
+          child: Text(
+            chatStyle.galleryButtonStyle!.text!,
+            style: chatStyle.galleryButtonStyle!.textStyle,
+          ),
+        ),
+        MenuItemButton(
+          leadingIcon: Icon(
+            chatStyle.attachFileButtonStyle!.icon!,
+            color: chatStyle.attachFileButtonStyle!.iconColor,
+          ),
+          onPressed: () => _onFile(),
+          child: Text(
+            chatStyle.attachFileButtonStyle!.text!,
+            style: chatStyle.attachFileButtonStyle!.textStyle,
+          ),
+        ),
+      ];
 
       return MenuAnchor(
         style: MenuStyle(
           backgroundColor: WidgetStateProperty.all(chatStyle.menuColor),
         ),
-        // Force menu above by using negative offset equal to estimated menu height
-        alignmentOffset: Offset(0, -estimatedMenuHeight),
+        // Force menu above by using negative offset equal to estimated menu
+        // height. NOTE: This is a hack to get the menu to appear above the
+        // button so that it doesn't appear below the soft keyboard. There
+        // should be no reason to set the alignmentOffset at all once this bug
+        // is fixed: https://github.com/flutter/flutter/issues/142921
+        alignmentOffset: _menuAnchorAlignmentOffsetHackForMobile(
+          chatStyle,
+          menuItems.length,
+        ),
         consumeOutsideTap: true,
         builder:
             (_, controller, _) => ActionButton(
@@ -120,6 +109,23 @@ class _AttachmentActionBarState extends State<AttachmentActionBar> {
       );
     },
   );
+
+  Offset? _menuAnchorAlignmentOffsetHackForMobile(
+    LlmChatViewStyle chatStyle,
+    int menuItems,
+  ) {
+    // Limit the potential damage on this hack to mobile platforms
+    if (!isMobile) return null;
+
+    // From MenuAnchor source: minimum height is 48.0 + some padding for
+    // safety
+    final double itemHeight = 48.0 + 8.0;
+    final double menuPadding = 16.0;
+
+    // Calculate menu height based on actual number of items
+    final double estimatedMenuHeight = (menuItems * itemHeight) + menuPadding;
+    return Offset(0, -estimatedMenuHeight);
+  }
 
   void _onCamera() => unawaited(_pickImage(ImageSource.camera));
   void _onGallery() => unawaited(_pickImage(ImageSource.gallery));

--- a/lib/src/views/chat_input/attachments_action_bar.dart
+++ b/lib/src/views/chat_input/attachments_action_bar.dart
@@ -44,56 +44,79 @@ class _AttachmentActionBarState extends State<AttachmentActionBar> {
     _canCamera = canTakePhoto();
   }
 
+  /// Estimates the height of a MenuItemButton based on Material Design specs
+  double _estimateMenuItemHeight(BuildContext context) {
+    // From MenuAnchor source: minimum height is 48.0
+    // Add some padding for safety
+    return 48.0 + 8.0; // 56.0 total per item
+  }
+
+  /// Builds the menu items list to avoid duplication
+  List<Widget> _buildMenuItems(LlmChatViewStyle chatStyle) {
+    return [
+      if (_canCamera)
+        MenuItemButton(
+          leadingIcon: Icon(
+            chatStyle.cameraButtonStyle!.icon!,
+            color: chatStyle.cameraButtonStyle!.iconColor,
+          ),
+          onPressed: () => _onCamera(),
+          child: Text(
+            chatStyle.cameraButtonStyle!.text!,
+            style: chatStyle.cameraButtonStyle!.textStyle,
+          ),
+        ),
+      MenuItemButton(
+        leadingIcon: Icon(
+          chatStyle.galleryButtonStyle!.icon!,
+          color: chatStyle.galleryButtonStyle!.iconColor,
+        ),
+        onPressed: () => _onGallery(),
+        child: Text(
+          chatStyle.galleryButtonStyle!.text!,
+          style: chatStyle.galleryButtonStyle!.textStyle,
+        ),
+      ),
+      MenuItemButton(
+        leadingIcon: Icon(
+          chatStyle.attachFileButtonStyle!.icon!,
+          color: chatStyle.attachFileButtonStyle!.iconColor,
+        ),
+        onPressed: () => _onFile(),
+        child: Text(
+          chatStyle.attachFileButtonStyle!.text!,
+          style: chatStyle.attachFileButtonStyle!.textStyle,
+        ),
+      ),
+    ];
+  }
+
   @override
   Widget build(BuildContext context) => ChatViewModelClient(
     builder: (context, viewModel, child) {
       final chatStyle = LlmChatViewStyle.resolve(viewModel.style);
+      final menuItems = _buildMenuItems(chatStyle);
+
+      // Calculate menu height based on actual number of items
+      final double itemHeight = _estimateMenuItemHeight(context);
+      final double menuPadding =
+          16.0; // Menu vertical padding from MenuAnchor source
+      final double estimatedMenuHeight =
+          (menuItems.length * itemHeight) + menuPadding;
+
       return MenuAnchor(
         style: MenuStyle(
           backgroundColor: WidgetStateProperty.all(chatStyle.menuColor),
         ),
+        // Force menu above by using negative offset equal to estimated menu height
+        alignmentOffset: Offset(0, -estimatedMenuHeight),
         consumeOutsideTap: true,
         builder:
             (_, controller, _) => ActionButton(
               onPressed: controller.isOpen ? controller.close : controller.open,
               style: chatStyle.addButtonStyle!,
             ),
-        menuChildren: [
-          if (_canCamera)
-            MenuItemButton(
-              leadingIcon: Icon(
-                chatStyle.cameraButtonStyle!.icon!,
-                color: chatStyle.cameraButtonStyle!.iconColor,
-              ),
-              onPressed: () => _onCamera(),
-              child: Text(
-                chatStyle.cameraButtonStyle!.text!,
-                style: chatStyle.cameraButtonStyle!.textStyle,
-              ),
-            ),
-          MenuItemButton(
-            leadingIcon: Icon(
-              chatStyle.galleryButtonStyle!.icon!,
-              color: chatStyle.galleryButtonStyle!.iconColor,
-            ),
-            onPressed: () => _onGallery(),
-            child: Text(
-              chatStyle.galleryButtonStyle!.text!,
-              style: chatStyle.galleryButtonStyle!.textStyle,
-            ),
-          ),
-          MenuItemButton(
-            leadingIcon: Icon(
-              chatStyle.attachFileButtonStyle!.icon!,
-              color: chatStyle.attachFileButtonStyle!.iconColor,
-            ),
-            onPressed: () => _onFile(),
-            child: Text(
-              chatStyle.attachFileButtonStyle!.text!,
-              style: chatStyle.attachFileButtonStyle!.textStyle,
-            ),
-          ),
-        ],
+        menuChildren: menuItems,
       );
     },
   );


### PR DESCRIPTION
This PR uses a work-around to fix [a Flutter bug](https://github.com/flutter/flutter/issues/142921) that puts a pop-up menu behind the software keyboard if it's showing on mobile.

# issues are fixed by this PR
- https://github.com/flutter/ai/issues/112

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.