### PR TITLE
Fixes ChatInput obscure issue

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -31,6 +31,7 @@ class ChatPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => Scaffold(
+    resizeToAvoidBottomInset: true,
     appBar: AppBar(title: const Text(App.title)),
     body: LlmChatView(
       provider: FirebaseProvider(

--- a/lib/src/views/llm_chat_view/llm_chat_view.dart
+++ b/lib/src/views/llm_chat_view/llm_chat_view.dart
@@ -212,21 +212,23 @@ class _LlmChatViewState extends State<LlmChatView>
                         ],
                       ),
                     ),
-                    ChatInput(
-                      initialMessage: _initialMessage,
-                      autofocus:
-                          widget.autofocus ??
-                          widget.viewModel.suggestions.isEmpty,
-                      onCancelEdit:
-                          _associatedResponse != null ? _onCancelEdit : null,
-                      onSendMessage: _onSendMessage,
-                      onCancelMessage:
-                          _pendingPromptResponse == null
-                              ? null
-                              : _onCancelMessage,
-                      onTranslateStt: _onTranslateStt,
-                      onCancelStt:
-                          _pendingSttResponse == null ? null : _onCancelStt,
+                    SafeArea(
+                      child: ChatInput(
+                        initialMessage: _initialMessage,
+                        autofocus:
+                            widget.autofocus ??
+                            widget.viewModel.suggestions.isEmpty,
+                        onCancelEdit:
+                            _associatedResponse != null ? _onCancelEdit : null,
+                        onSendMessage: _onSendMessage,
+                        onCancelMessage:
+                            _pendingPromptResponse == null
+                                ? null
+                                : _onCancelMessage,
+                        onTranslateStt: _onTranslateStt,
+                        onCancelStt:
+                            _pendingSttResponse == null ? null : _onCancelStt,
+                      ),
                     ),
                   ],
                 ),


### PR DESCRIPTION

Fixes ChatInput obscure issue.

After:
<img width="1080" height="2400" alt="Screenshot_20251027-165305" src="https://github.com/user-attachments/assets/aff2691b-e417-4a8c-aee6-353b26695a8d" />

Before:

<img width="1173" height="2446" alt="Screenshot_20251027-165046" src="https://github.com/user-attachments/assets/41b9e41f-e60a-493f-bf95-2d9433a8d83f" />

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
